### PR TITLE
Correct regex

### DIFF
--- a/mem_watch.py
+++ b/mem_watch.py
@@ -52,7 +52,7 @@ class NVIDIA_MEM_GUI():
 
         r = check_output(["nvidia-smi"])
 
-        mem_string = re.findall("\d+MiB / \d+MiB",r)
+        mem_string = re.findall("\d+MiB \/\s+\d+MiB",r)
         sizes = map(float, re.findall("\d+", mem_string[0]))
         self.max_gpu_mem = sizes[1]
         self.current_gpu_mem = sizes[0]


### PR DESCRIPTION
Didn't work for me because the output of nvidia-smi had two spaces after the "slash". Regex update corrected this.